### PR TITLE
Issue #1: resolve Test Failure

### DIFF
--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -60,13 +60,13 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
         org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=AAPL")
+            .get("/iex/lastTradedPrice?symbols=FB")
             // This URL will be hit by the MockMvc client. The result is configured in the file
             // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].symbol", is("FB")))
-        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.34")))
+        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
         .andReturn();
   }
 

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -6,7 +6,7 @@
     "method" : "GET"
   },
   "response" : {
-    "status" : 404,
+    "status" : 200,
     "jsonBody" : [{"symbol":"FB","price":186.3011,"size":100,"time":1565273330617}],
     "headers" : {
       "Server" : "nginx",


### PR DESCRIPTION
### Issue 1: Resolve Test Failure
The IexRestControllerTest testGetLastTradedPrice() is failing due to a merge issue. Resolve the test failure.

### Test Evidence
There were three issues to be resolved. The get request was requesting the lastTradedPrice for AAPL and the test was expecting the symbol to be FB. This was resolved by changing the get request to request for FB instead of AAPL.

Additionally the expected price was different from what was being return for the price in the mapping-lastTradedPrice.json. This was changed to match the returned request.

Finally, the mapping-lastTradedPrice.json was return a status of 404 despite it being a successful request. This was changed from a status 404 to status 200.

![p1](https://user-images.githubusercontent.com/44921741/120843933-b4629000-c53c-11eb-8f01-5a60e80db6c0.PNG)

